### PR TITLE
Added initial u-boot support for multiple rootfs by changing the defa…

### DIFF
--- a/include/configs/sunxi-common.h
+++ b/include/configs/sunxi-common.h
@@ -543,6 +543,19 @@ extern int soft_i2c_gpio_scl;
 	"usbnet_devaddr=de:ad:be:af:00:01\0" \
 	"mtdids=nand0=sunxi-nand.0\0" \
 	"mtdparts=mtdparts=sunxi-nand.0:4m(spl),4m(spl-backup),4m(uboot),4m(env),-(UBI)\0" \
+        "activate_bootargs_primary=setenv bootargs root=ubi0:primary-rootfs rootfstype=ubifs rw earlyprintk ubi.mtd=4\0" \
+        "activate_bootargs_secondary=setenv bootargs root=ubi0:secondary-rootfs rootfstype=ubifs rw earlyprintk ubi.mtd=4\0" \
+        "activate_bootargs_primary_initrd=setenv bootargs root=ubi0:primary-rootfs rootfstype=ubifs ro earlyprintk ubi.mtd=4\0" \
+        "activate_bootargs_secondary_initrd=setenv bootargs root=ubi0:secondary-rootfs rootfstype=ubifs ro earlyprintk ubi.mtd=4\0" \
+        "boot_primary=echo booting primary; run activate_bootargs_primary; mtdparts; ubi part UBI; ubifsmount ubi0:primary-rootfs; ubifsload $fdt_addr_r /boot/sun5i-r8-chip.dtb; ubifsload $kernel_addr_r /boot/zImage; bootz $kernel_addr_r - $fdt_addr_r\0" \
+        "boot_secondary=echo booting secondary; run activate_bootargs_secondary; mtdparts; ubi part UBI; ubifsmount ubi0:secondary-rootfs; ubifsload $fdt_addr_r /boot/sun5i-r8-chip.dtb; ubifsload $kernel_addr_r /boot/zImage; bootz $kernel_addr_r - $fdt_addr_r\0" \
+        "set_active_and_fallback=mtdparts; ubi part UBI; ubifsmount ubi0:root-config; if ubifsls /secondary-rootfs; then setenv active secondary; setenv fallback primary; else setenv active primary; setenv fallback secondary; fi\0" \
+        "boot_primary_initrd=echo booting primary; run activate_bootargs_primary_initrd; mtdparts; ubi part UBI; ubifsmount ubi0:primary-rootfs; ubifsload $fdt_addr_r /boot/sun5i-r8-chip.dtb; ubifsload 0x44000000 /boot/initrd.uimage; ubifsload $kernel_addr_r /boot/zImage; bootz $kernel_addr_r 0x44000000 $fdt_addr_r\0" \
+        "boot_secondary_initrd=echo booting secondary; run activate_bootargs_secondary_initrd; mtdparts; ubi part UBI; ubifsmount ubi0:secondary-rootfs; ubifsload $fdt_addr_r /boot/sun5i-r8-chip.dtb; ubifsload 0x44000000 /boot/initrd.uimage; ubifsload $kernel_addr_r /boot/zImage; bootz $kernel_addr_r 0x44000000 $fdt_addr_r\0" \
+        "boot_chain=fel ubi\0" \
+        "call_bootchain=for entry in ${boot_chain}; do run bootcmd_${entry}; done\0" \
+        "bootcmd_ubi=run set_active_and_fallback; run boot_${active}_initrd; run boot_${active}; run boot_${fallback}_initrd; run boot_${fallback}\0" \
+        "bootcmd=run call_bootchain\0" \
 	BOOTENV
 
 #else /* ifndef CONFIG_SPL_BUILD */


### PR DESCRIPTION
…ult u-boot-env
This patch implements support for more than one rootfs in u-boot.
Requirements:
- u-boot expects two rootfs placed in ubifs volumes with the names primary-rootfs and secondary-rootfs (chip-create-nand-images.sh needs to be changed)
- It also expects that a root-config volume exists (chip-create-nand-images.sh needs to be changed)
- The u-boot environment partition is not allowed to be valid, because otherwise the patched default environment is not used (chip-flash-nand-images.sh needs to be changed)
I will do this next.

What is does on boot:
- Mount the root-config
- If a file called secondary-rootfs exists in the volume it will activate the seconday-rootfs as active, otherwise the primary-rootfs (if no file exists in root-config the primary-rootfs is the active one)
- The not active rootfs is marked as fallback
- Try to boot the active rootfs (first its tried to boot with initramfs, and then without, our current debian distribution doesn't need initramfs, but in the long run we need it as a preparation step, so we need to support both approaches)
- If the active rootfs cannot boot, it will try the fallback rootfs

How its done:
The boot is configured in u-boot via the boot environment. This can be fetched from a dedicated environment partition or if this one is not valid u-boot will use its build in default. U-boot can be forced to use the internal default, by invalidating the environment partition.
The patch changes the default environment removing the need of a u-boot environment partition and with it a possibility for errors.